### PR TITLE
adding CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,42 @@ checkEnv(['REQUIRED_VAR', 'OTHER_VAR', 'ENV_VAR']);
 // => Throws an error if one of the variables aren't set.
 ```
 
+## CLI Usage
+
+1. Install as a project dependency as above
+2. Add to a [lifecycle script](https://docs.npmjs.com/misc/scripts) such as
+   `prestart`
+3. `npm start` will bail out (`exit(1)`) with a hard to miss error message if env vars are not set
+
+### Example:
+
+In package.json:
+
+```json
+{
+  "prestart": "check-env AWS_KEY MONGO_URL",
+  "start": "node ./mongo_api.js"
+}
+```
+
+
+```
+$ echo $MONGO_URL
+# (nothing)
+
+$ npm start
+ ________________________________________
+< Missing environment variable MONGO_URL >
+ ----------------------------------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+
+$ echo $?
+1
+```
 
 ## License
 

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const check = require('./index.js');
+const cowsay = require('cowsay');
+
+try{
+  check(process.argv.slice(2));
+}catch(e){
+  console.error(cowsay.say({
+    text : e.message,
+  }));
+  process.exit(1);
+}
+
+// OK
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "check-env",
+  "name": "@sequoia/check-env",
   "version": "1.3.0",
   "description": "Makes sure that all required environment variables are set.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.2.0",
   "description": "Makes sure that all required environment variables are set.",
   "repository": {
-      "type": "git",
-      "url": "git@github.com:ekmartin/check-env.git"
+    "type": "git",
+    "url": "git@github.com:ekmartin/check-env.git"
   },
   "main": "index.js",
+  "bin" : "bin.js",
   "scripts": {
     "test": "make test"
   },
@@ -16,5 +17,8 @@
     "istanbul": "^0.4.2",
     "jshint": "^2.6.0",
     "mocha": "^3.1.1"
+  },
+  "dependencies": {
+    "cowsay": "^1.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "check-env",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Makes sure that all required environment variables are set.",
   "repository": {
     "type": "git",
     "url": "git@github.com:ekmartin/check-env.git"
   },
   "main": "index.js",
-  "bin" : "bin.js",
+  "bin": "bin.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Adding CLI so it this can be installed as a package dep & used in npm scripts.

Example:

```json
{
  "prestart": "check-env MONGO_URL",
  "start": "node ./mongo_api.js"
}
```

If the env variable isn't set it bails out (`exit(1)`) with a big, hard to miss error message:

```
 ________________________________________
< Missing environment variable MONGO_URL >
 ----------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```